### PR TITLE
Add .vscode/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ notes/
 *.pyc
 .idea/
 dump/
+.vscode/


### PR DESCRIPTION
Mirrors the existing .idea/ entry for JetBrains IDEs, so VS Code workspace settings aren't accidentally committed by contributors.